### PR TITLE
default unit to "short" if not set in indicator docs

### DIFF
--- a/pkg/grafana_dashboard/grafana.go
+++ b/pkg/grafana_dashboard/grafana.go
@@ -126,13 +126,18 @@ func ToGrafanaPanel(spec v1.IndicatorSpec) *sdk.Panel {
 	panel.GraphPanel.Description = ToGrafanaDescription(spec.Documentation)
 	panel.GraphPanel.Thresholds = ToGrafanaThresholds(spec.Thresholds)
 
+	unit := "short"
+	if spec.Presentation.Units != "" {
+		unit = spec.Presentation.Units
+	}
+
 	panel.GraphPanel.Yaxes = []sdk.Axis{
 		{
-			Format: spec.Presentation.Units,
+			Format: unit ,
 			Show:   true,
 		},
 		{
-			Format: spec.Presentation.Units,
+			Format: unit,
 		},
 	}
 

--- a/pkg/grafana_dashboard/grafana_test.go
+++ b/pkg/grafana_dashboard/grafana_test.go
@@ -141,6 +141,37 @@ test title
 		g.Expect(anotherDashboard.Panels[1].GraphPanel.Thresholds).To(HaveLen(2))
 	})
 
+	t.Run("set default unit to short if not provided in presentation", func(t *testing.T) {
+		buffer := bytes.NewBuffer(nil)
+		log.SetOutput(buffer)
+
+		g := NewGomegaWithT(t)
+		document := v1.IndicatorDocument{
+			Spec: v1.IndicatorDocumentSpec{
+				Indicators: []v1.IndicatorSpec{
+					{
+						Name:          "test_indicator",
+						PromQL:        `sum_over_time(gorouter_latency_ms[30m])`,
+					},
+				},
+				Layout: v1.Layout{
+					Title: "Indicator Test Dashboard",
+					Sections: []v1.Section{
+						{
+							Title:      "Test Section Title",
+							Indicators: []string{"test_indicator"},
+						},
+					},
+				},
+			},
+		}
+
+		dashboard, err := grafana_dashboard.ToGrafanaDashboard(document, v1.UndefinedType)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(dashboard.Panels[1].Yaxes[0].Format).To(Equal("short"))
+	})
+
 	t.Run("takes indicator documentation and turns it into a graph description", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 


### PR DESCRIPTION
otherwise grafana would not render graphs properly

Signed-off-by: Huan Wang <huwang@pivotal.io>